### PR TITLE
reverting previous lint change

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -49,7 +49,7 @@ define selinux::module(
   exec { "${name}-checkloaded":
     refreshonly => false,
     creates     => "/etc/selinux/${::selinux_config_policy}/modules/active/modules/${name}.pp",
-    command     => true,
+    command     => 'true',
     notify      => Exec["${name}-buildmod"],
   }
 


### PR DESCRIPTION
Without the quotes, Puppet 3.7 breaks.