### PR TITLE
fix change-selinux-status in case of selinux disabled

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -62,7 +62,7 @@ class selinux::config (
 
     exec { "change-selinux-status-to-${mode}":
       command => "setenforce ${sestatus}",
-      unless  => "getenforce | grep -qi ${mode}",
+      unless  => "getenforce | grep -qi \"${mode}\\|disabled\"",
       path    => '/bin:/usr/bin:/usr/sbin',
     }
   } else {


### PR DESCRIPTION
If selinux is disabled, setenforce will fail when trying to change the status. This can be changed only with a reboot.