### PR TITLE
Better compatibility with CentOS 7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,8 +12,8 @@ class selinux::params {
   $package_ensure = present
 
   $sx_fs_mount  = $::osfamily ? {
-    'RedHat' => $::operatingsystemrelease ? {
-      /^7\./        => '/sys/fs/selinux',
+    'RedHat' => $::operatingsystemmajrelease ? {
+      '7'           => '/sys/fs/selinux',
       default       => '/selinux',
     },
     default         => '/selinux',


### PR DESCRIPTION
Since Facter 2.2 you can use $operatingsystemmajrelease which avoids the stupid numbering used by CentOS 7 and means you don't have to match a regex