### PR TITLE
Feature: add support for templating .te files

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -48,7 +48,7 @@ Deploy a custom module:
 ```puppet
 selinux::module { 'resnet-puppet':
   ensure => 'present',
-  source => 'puppet:///modules/site_puppet/site-puppet.te',
+  content => template(modulename/module.te',
 }
 ```
 

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -27,7 +27,8 @@
 #  }
 #
 define selinux::module(
-  $content,
+  $content        = '',
+  $source         = '',
   $ensure         = 'present',
   $use_makefile   = false,
   $makefile       = '/usr/share/selinux/devel/Makefile',
@@ -54,10 +55,18 @@ define selinux::module(
   }
 
   ## Begin Configuration
-  file { "${::selinux::params::sx_mod_dir}/${name}.te":
-    ensure  => $ensure,
-    content => $content,
-    tag     => 'selinux-module',
+  if $content {
+    file { "${::selinux::params::sx_mod_dir}/${name}.te":
+      ensure  => $ensure,
+      content => $content,
+      tag     => 'selinux-module',
+    }
+  } else {
+    file { "${::selinux::params::sx_mod_dir}/${name}.te":
+      ensure  => $ensure,
+      source  => $source,
+      tag     => 'selinux-module',
+    }
   }
   if !$use_makefile {
     file { "${::selinux::params::sx_mod_dir}/${name}.mod":

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -27,7 +27,7 @@
 #  }
 #
 define selinux::module(
-  $source,
+  $content,
   $ensure         = 'present',
   $use_makefile   = false,
   $makefile       = '/usr/share/selinux/devel/Makefile',
@@ -55,9 +55,9 @@ define selinux::module(
 
   ## Begin Configuration
   file { "${::selinux::params::sx_mod_dir}/${name}.te":
-    ensure => $ensure,
-    source => $source,
-    tag    => 'selinux-module',
+    ensure  => $ensure,
+    content => $content,
+    tag     => 'selinux-module',
   }
   if !$use_makefile {
     file { "${::selinux::params::sx_mod_dir}/${name}.mod":


### PR DESCRIPTION
Hi,

I needed to be able to support this, and I think it might be useful for others. Basically, source doesn't support templates, meaning .te files can only be static. Using content, we can still use the file() function, but also use template(). I've changed the README to reflect the change. Please ping me if there's any additional garnishes that you'd like.