### PR TITLE
Workaround for RH 7 variants

### DIFF
--- a/lib/facter/selinux_custom_policy.rb
+++ b/lib/facter/selinux_custom_policy.rb
@@ -1,0 +1,11 @@
+# selinux_custom_policy.rb
+
+Facter.add(:selinux_custom_policy) do
+  confine :kernel => 'Linux', :osfamily => 'RedHat', :operatingsystemmajrelease => '7', :selinux => true
+
+  selinux_custom_policy = Facter::Core::Execution.exec('sestatus | grep "Loaded policy name" | awk \'{print $4}\'')
+
+  setcode do
+    selinux_custom_policy
+  end
+end

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -35,6 +35,15 @@ define selinux::module(
 
   include selinux
 
+  if $::selinux_config_policy in ['targeted','strict']
+  {
+    $selinux_policy = $::selinux_config_policy
+  }
+  elsif $::selinux_custom_policy
+  {
+    $selinux_policy = $::selinux_custom_policy
+  }
+
   # Set Resource Defaults
   File {
     owner => 'root',
@@ -51,7 +60,7 @@ define selinux::module(
 
   exec { "${name}-checkloaded":
     refreshonly => false,
-    creates     => "/etc/selinux/${::selinux_config_policy}/modules/active/modules/${name}.pp",
+    creates     => "/etc/selinux/${selinux_policy}/modules/active/modules/${name}.pp",
     command     => 'true',
     notify      => Exec["${name}-buildmod"],
   }


### PR DESCRIPTION
Small workaround to fix the module running on RH 7 variants, detailed in [issue 27](https://github.com/jfryman/puppet-selinux/issues/27)

Provide a new custom fact that will only execute on RH 7 variants with SELinux enabled, and use that to determine the policy in module.pp if the default selinux_config_policy fact is not either 'targeted' or 'strict'.