### PR TITLE
Use "defined" instead of "getvar" to protect against undefined variables when strict_variables=yes

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,7 +39,7 @@ class selinux::config (
   case $mode {
     permissive, disabled: {
       $sestatus = '0'
-      if $mode == 'disabled' and getvar('::selinux_current_mode') == 'permissive' {
+      if $mode == 'disabled' and defined('$::selinux_current_mode') and $::selinux_current_mode == 'permissive' {
         notice('A reboot is required to fully disable SELinux. SELinux will operate in Permissive mode until a reboot')
       }
     }


### PR DESCRIPTION
I got into a discussion with @richardc about strict_variables and getvar.

tl;dr: use "defined" not "getvar" to protect against undefined variables.