### PR TITLE
Allow Scientific Linux as a valid OS

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,21 +12,21 @@ class selinux::params {
 
   case $::osfamily {
     'RedHat': {
-      case $::operatingsystemmajrelease {
-        '7': {
+      case $::operatingsystemrelease {
+        /^7/: {
           $sx_fs_mount = '/sys/fs/selinux'
           $package_name = 'policycoreutils-python'
         }
-        '6': {
+        /^6/: {
           $sx_fs_mount = '/selinux'
           $package_name = 'policycoreutils-python'
         }
-        '5': {
+        /^5/: {
           $sx_fs_mount = '/selinux'
           $package_name = 'policycoreutils'
         }
         default: {
-          fail("${::osfamily}-${::operatingsystemmajrelease} is not supported")
+          fail("${::osfamily}-${::operatingsystemrelease} is not supported")
         }
       }
     }


### PR DESCRIPTION
Scientific Linux doesn't have a operatingsystemmajrelease so we
can't just look for v 5/6/7 etc, we need to query operatingsystemrelease

It may be better to query all of these on operatingsystemrelease
but I don't have a redhat box to query to confirm this works.