### PR TITLE
Make port exec statement unique for protocol

### DIFF
--- a/manifests/port.pp
+++ b/manifests/port.pp
@@ -46,11 +46,13 @@ define selinux::port (
   if $protocol {
     validate_re($protocol, ['^tcp6?$', '^udp6?$'])
     $protocol_switch="-p ${protocol} "
+    $port_exec_command = "add_${context}_${port}_${protocol}"
   } else {
     $protocol_switch=''
+    $port_exec_command = "add_${context}_${port}"
   }
 
-  exec { "add_${context}_${port}":
+  exec { $port_exec_command:
     command => "semanage port -a -t ${context} ${protocol_switch}${port}",
     unless  => "semanage port -l|grep \"^${context}.*${protocol}.*${port}\"|grep -w ${port}",
     path    => '/bin:/sbin:/usr/bin:/usr/sbin',

--- a/spec/defines/selinux_port_spec.rb
+++ b/spec/defines/selinux_port_spec.rb
@@ -7,7 +7,7 @@ describe 'selinux::port' do
   ['tcp', 'udp', 'tcp6', 'udp6'].each do |protocol|
     context "valid protocol #{protocol}" do
       let(:params) { { :context => 'http_port_t', :port => 8080, :protocol => protocol } }
-      it { should contain_exec('add_http_port_t_8080').with(:command => "semanage port -a -t http_port_t -p #{protocol} 8080") }
+      it { should contain_exec("add_http_port_t_8080_#{protocol}").with(:command => "semanage port -a -t http_port_t -p #{protocol} 8080") }
     end
   end
 
@@ -17,8 +17,8 @@ describe 'selinux::port' do
   end
 
   context 'no protocol' do
-    let(:params) { { :context => 'http_port_t', :port => 8080 } }
-    it { should contain_exec('add_http_port_t_8080').with(:command => 'semanage port -a -t http_port_t 8080') }
+    let(:params) { { :context => 'http_port_t', :port => 8080} }
+    it { should contain_exec("add_http_port_t_8080").with(:command => 'semanage port -a -t http_port_t 8080') }
   end
 
 end


### PR DESCRIPTION
If you have the same port allowed on both udp & tcp the puppet manifest
will fail as you have a duplicate name, this change adds the protocol
name into port definition