### PR TITLE
Bug fix for declaring multiple selinux::module types

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -69,15 +69,15 @@ define selinux::module(
   file { "${::selinux::params::sx_mod_dir}/${name}.te":
     ensure => $ensure,
     source => $source,
-    tag    => 'selinux-module',
+    tag    => "selinux-module-${name}",
   }
   if !$use_makefile {
     file { "${::selinux::params::sx_mod_dir}/${name}.mod":
-      tag   => ['selinux-module-build', 'selinux-module'],
+      tag   => ["selinux-module-build-${name}", "selinux-module-${name}"],
     }
   }
   file { "${::selinux::params::sx_mod_dir}/${name}.pp":
-    tag   => ['selinux-module-build', 'selinux-module'],
+    tag   => ["selinux-module-build-${name}", "selinux-module-${name}"],
   }
 
   # Specific executables based on present or absent.
@@ -107,7 +107,7 @@ define selinux::module(
       ~> Exec["${name}-buildmod"]
       ~> Exec["${name}-buildpp"]
       ~> Exec["${name}-install"]
-      -> File<| tag == 'selinux-module-build' |>
+      -> File<| tag == "selinux-module-build-${name}" |>
     }
     absent: {
       exec { "${name}-remove":
@@ -116,7 +116,7 @@ define selinux::module(
 
       # Set dependency ordering
       Exec["${name}-remove"]
-      -> File<| tag == 'selinux-module' |>
+      -> File<| tag == "selinux-module-${name}" |>
     }
     default: {
       fail("Invalid status for SELinux Module: ${ensure}")

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
 "name": "jfryman/selinux",
-"version": "0.2.3",
+"version": "0.2.4",
 "author": "jfryman",
 "summary": "This class manages SELinux on RHEL based systems",
 "license": "Apache-2.0",


### PR DESCRIPTION
Hello Mr. Fryman

I recently began using trying out this module, and ran into a peculiar issue. When I try to have two selinux::module declarations get applied to the same host (which should be possible, seeing as how it's a defined type), I get catalog cycle dependency errors. Having multiple selinux::module types defined in such a way that one is dependent on the other (such as having them in separate profile manifests where other contents of the profile require ordering at the role manifest level) appears to be the trigger for the issue. Having read the type definition and thinking about it a bit, I believe the root issue is the way you used tags in the file declarations. While it's a neat trick to work around not knowing if you'll have a .mod file declaration ahead of time, you don't have anything unique in the tag names. As such, when you use the collector to chain resources, the tag search doesn't distinguish between file declarations from this instance of the defined type and other instances of it in the catalog. My proposed workaround is to replace 'selinux-module-build' and 'selinux-module' with 'selinux-module-build-${name}' and  'selinux-module-${name}', respectively. I've tested this method out, and it appears to resolve the issue, without changing anything external or breaking anything (meaning this can be a simple bugfix version release semantically). I'm open to suggestions about how else to handle this, if there's a more preferable way.