### PR TITLE
Added Restorecon to puppet-selinux module

### DIFF
--- a/manifests/restorecon.pp
+++ b/manifests/restorecon.pp
@@ -1,0 +1,38 @@
+# Definition: selinux::restorecon
+#
+# Description
+#  This method provides the restorecon command. After running the restorecon, the file will have 
+#  the correct context re-applied and the changes will be made permanent.
+#
+# Parameters:
+#   - $pathname: path of the file to which the context needs to be re-applied.
+#
+# Actions:
+#  Runs "restorecon" with options to persistently set the file context
+#
+# Requires:
+#  - SELinux
+#  - policycoreutils-python (for el-based systems)
+#
+# Sample Usage:
+#  selinux::restorecon{'restore-project-log-context':
+#     pathname => "/var/log/project/",
+#  }
+#
+
+define selinux::restorecon (
+  $pathname,
+) {
+
+  include selinux
+
+  $resource_name = "add_restorecon_${pathname}"
+  $command       = "restorecon -R -v \"${pathname}\""
+
+  exec { $resource_name:
+    command => $command,
+    path    => '/bin:/sbin:/usr/bin:/usr/sbin',
+    require => Class['selinux::package'],
+  }
+}
+

--- a/tests/restorecon.pp
+++ b/tests/restorecon.pp
@@ -1,3 +1,3 @@
 selinux::restorecon{'restore-project-log-context':
-  pathname => "/var/log/project/",
+  pathname => "/var/log",
 }

--- a/tests/restorecon.pp
+++ b/tests/restorecon.pp
@@ -1,0 +1,3 @@
+selinux::restorecon{'restore-project-log-context':
+  pathname => "/var/log/project/",
+}


### PR DESCRIPTION
I used the semanage fcontext command from the puppet-selinux module (with httpd_log_t context) applied to a log folder that had two log files inside it.
After doing ls-LZ the context was reflected on the folder but it was not applied to the internal log files. 
After a research on net I found that a restorecon command is required to run for applying the context changes.
So I have created a pull request to add the restorecon command to Puppet-selinux module. Can you please review it.
