### PR TITLE
fcontext command escaping

### DIFF
--- a/lib/puppet/parser/functions/selinux_escape_perl_regexp.rb
+++ b/lib/puppet/parser/functions/selinux_escape_perl_regexp.rb
@@ -1,0 +1,21 @@
+module Puppet::Parser::Functions
+    newfunction(:selinux_escape_perl_regexp, :type => :rvalue, :doc => <<-EOS
+
+Escape a string so that it can be used within a perl regular expression to match a static string.
+All special regexp characters will be escaped.
+
+For example:
+
+    $escapedRegexp = selinux_escape_perl_regexp($mystring)
+    $escapedShell = selinux_sh_escape($escapedRegexp)
+    exec { 'foo':
+        command => "grep -P '^\d+:${escapedShell}\$' foo.txt"
+    }
+
+  EOS
+) do |args|
+    str = args[0]
+    str = str.gsub(/\\E/, '\\E\\\\\\\\E\\Q')
+    return '\\Q' + str + '\\E'
+  end
+end

--- a/lib/puppet/parser/functions/selinux_sh_escape.rb
+++ b/lib/puppet/parser/functions/selinux_sh_escape.rb
@@ -1,0 +1,20 @@
+module Puppet::Parser::Functions
+  newfunction(:selinux_sh_escape, :type => :rvalue, :doc => <<-EOS
+
+Escape a string so that it can be passed on the shell within a single quoted string.
+
+All single quotes within the string will be escaped
+
+For example:
+
+    $escaped = selinux_sh_escape($mystring)
+    exec { 'foo':
+        command => "/usr/bin/mv '{$escaped}' foo.txt"
+    }
+
+  EOS
+  ) do |args|
+    str = args[0]
+    return str.gsub(/'/, %q!'"'"'!)
+  end
+end

--- a/manifests/fcontext.pp
+++ b/manifests/fcontext.pp
@@ -88,18 +88,23 @@ define selinux::fcontext (
     fail('file mode must be one of: a,f,d,c,b,s,l,p - see "man semanage-fcontext"')
   }
 
+  $destinationShell = selinux_sh_escape($destination)
+  $pathnameShell = selinux_sh_escape($pathname)
+  $destinationRegexp = selinux_sh_escape(selinux_escape_perl_regexp($destination))
+  $pathnameRegexp = selinux_sh_escape(selinux_escape_perl_regexp($pathname))
+
   if $equals {
     $resource_name = "add_${destination}_${pathname}"
-    $command       = "semanage fcontext -a -e \"${destination}\" \"${pathname}\""
-    $unless        = "semanage fcontext -l | grep -E \"^${pathname} = ${destination}$\""
+    $command       = "semanage fcontext -a -e '${destinationShell}' '${pathnameShell}'"
+    $unless        = "semanage fcontext -l | grep -P '^${pathnameRegexp} = ${destinationRegexp}\$'"
   } elsif $filetype {
     $resource_name = "add_${context}_${pathname}_type_${filemode}"
-    $command       = "semanage fcontext -a -f ${filemode} -t ${context} \"${pathname}\""
-    $unless        = "semanage fcontext -l | grep -E \"^${pathname}.*:${context}:\""
+    $command       = "semanage fcontext -a -f ${filemode} -t ${context} '${pathnameShell}'"
+    $unless        = "semanage fcontext -l | grep -P '^${pathnameRegexp}.*:${context}:'"
   } else {
     $resource_name = "add_${context}_${pathname}"
-    $command       = "semanage fcontext -a -t ${context} \"${pathname}\""
-    $unless        = "semanage fcontext -l | grep -E \"^${pathname}.*:${context}:\""
+    $command       = "semanage fcontext -a -t ${context} '${pathnameShell}'"
+    $unless        = "semanage fcontext -l | grep -P '^${pathnameRegexp}.*:${context}:'"
   }
 
   exec { $resource_name:

--- a/manifests/fcontext.pp
+++ b/manifests/fcontext.pp
@@ -100,11 +100,11 @@ define selinux::fcontext (
   } elsif $filetype {
     $resource_name = "add_${context}_${pathname}_type_${filemode}"
     $command       = "semanage fcontext -a -f ${filemode} -t ${context} '${pathnameShell}'"
-    $unless        = "semanage fcontext -l | grep -P '^${pathnameRegexp}.*:${context}:'"
+    $unless        = "semanage fcontext -l | grep -P '^${pathnameRegexp}\\x20.*:${context}:'"
   } else {
     $resource_name = "add_${context}_${pathname}"
     $command       = "semanage fcontext -a -t ${context} '${pathnameShell}'"
-    $unless        = "semanage fcontext -l | grep -P '^${pathnameRegexp}.*:${context}:'"
+    $unless        = "semanage fcontext -l | grep -P '^${pathnameRegexp}\\x20.*:${context}:'"
   }
 
   exec { $resource_name:

--- a/spec/defines/selinux_fcontext_spec.rb
+++ b/spec/defines/selinux_fcontext_spec.rb
@@ -40,7 +40,7 @@ describe 'selinux::fcontext' do
     let(:params) { { :pathname => '/tmp/file1', :filetype => true, :filemode => 'a', :context => 'user_home_dir_t' } }
     it { should contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(
       :command => 'semanage fcontext -a -f a -t user_home_dir_t \'/tmp/file1\'',
-      :unless => 'semanage fcontext -l | grep -P \'^\Q/tmp/file1\E.*:user_home_dir_t:\''
+      :unless => 'semanage fcontext -l | grep -P \'^\Q/tmp/file1\E\x20.*:user_home_dir_t:\''
     ) }
   end
 
@@ -48,7 +48,7 @@ describe 'selinux::fcontext' do
     let(:params) { { :pathname => '/tmp/f"i$le\'1', :filetype => true, :filemode => 'a', :context => 'user_home_dir_t' } }
     it { should contain_exec('add_user_home_dir_t_/tmp/f"i$le\'1_type_a').with(
       :command => %q!semanage fcontext -a -f a -t user_home_dir_t '/tmp/f"i$le'"'"'1'!,
-      :unless => %q!semanage fcontext -l | grep -P '^\Q/tmp/f"i$le'"'"'1\E.*:user_home_dir_t:'!
+      :unless => %q!semanage fcontext -l | grep -P '^\Q/tmp/f"i$le'"'"'1\E\x20.*:user_home_dir_t:'!
     ) }
   end
 
@@ -56,7 +56,7 @@ describe 'selinux::fcontext' do
     let(:params) { { :pathname => '/tmp/file1', :context => 'user_home_dir_t' } }
     it { should contain_exec('add_user_home_dir_t_/tmp/file1').with(
       :command => 'semanage fcontext -a -t user_home_dir_t \'/tmp/file1\'',
-      :unless => 'semanage fcontext -l | grep -P \'^\Q/tmp/file1\E.*:user_home_dir_t:\''
+      :unless => 'semanage fcontext -l | grep -P \'^\Q/tmp/file1\E\x20.*:user_home_dir_t:\''
     ) }
   end
 
@@ -64,7 +64,7 @@ describe 'selinux::fcontext' do
     let(:params) { { :pathname => '/tmp/f"i$le\'1', :context => 'user_home_dir_t' } }
     it { should contain_exec('add_user_home_dir_t_/tmp/f"i$le\'1').with(
       :command => %q!semanage fcontext -a -t user_home_dir_t '/tmp/f"i$le'"'"'1'!,
-      :unless => %q!semanage fcontext -l | grep -P '^\Q/tmp/f"i$le'"'"'1\E.*:user_home_dir_t:'!
+      :unless => %q!semanage fcontext -l | grep -P '^\Q/tmp/f"i$le'"'"'1\E\x20.*:user_home_dir_t:'!
     ) }
   end
 

--- a/spec/defines/selinux_fcontext_spec.rb
+++ b/spec/defines/selinux_fcontext_spec.rb
@@ -22,17 +22,50 @@ describe 'selinux::fcontext' do
 
   context 'substituting fcontext' do
     let(:params) { { :pathname => '/tmp/file1', :equals => true, :destination => '/tmp/file2' } }
-    it { should contain_exec('add_/tmp/file2_/tmp/file1').with(:command => 'semanage fcontext -a -e "/tmp/file2" "/tmp/file1"') }
+    it { should contain_exec('add_/tmp/file2_/tmp/file1').with(
+      :command => 'semanage fcontext -a -e \'/tmp/file2\' \'/tmp/file1\'',
+      :unless => 'semanage fcontext -l | grep -P \'^\Q/tmp/file1\E = \Q/tmp/file2\E$\''
+    ) }
+  end
+
+  context 'substituting fcontext with special characters' do
+    let(:params) { { :pathname => '/tmp/f"i$le\'1', :equals => true, :destination => '/tmp/f"i$le\'2' } }
+    it { should contain_exec('add_/tmp/f"i$le\'2_/tmp/f"i$le\'1').with(
+      :command => %q!semanage fcontext -a -e '/tmp/f"i$le'"'"'2' '/tmp/f"i$le'"'"'1'!,
+      :unless => %q!semanage fcontext -l | grep -P '^\Q/tmp/f"i$le'"'"'1\E = \Q/tmp/f"i$le'"'"'2\E$'!
+    ) }
   end
 
   context 'set filemode and context' do
     let(:params) { { :pathname => '/tmp/file1', :filetype => true, :filemode => 'a', :context => 'user_home_dir_t' } }
-    it { should contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(:command => 'semanage fcontext -a -f a -t user_home_dir_t "/tmp/file1"') }
+    it { should contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(
+      :command => 'semanage fcontext -a -f a -t user_home_dir_t \'/tmp/file1\'',
+      :unless => 'semanage fcontext -l | grep -P \'^\Q/tmp/file1\E.*:user_home_dir_t:\''
+    ) }
+  end
+
+  context 'set filemode and context with special characters' do
+    let(:params) { { :pathname => '/tmp/f"i$le\'1', :filetype => true, :filemode => 'a', :context => 'user_home_dir_t' } }
+    it { should contain_exec('add_user_home_dir_t_/tmp/f"i$le\'1_type_a').with(
+      :command => %q!semanage fcontext -a -f a -t user_home_dir_t '/tmp/f"i$le'"'"'1'!,
+      :unless => %q!semanage fcontext -l | grep -P '^\Q/tmp/f"i$le'"'"'1\E.*:user_home_dir_t:'!
+    ) }
   end
 
   context 'set context' do
     let(:params) { { :pathname => '/tmp/file1', :context => 'user_home_dir_t' } }
-    it { should contain_exec('add_user_home_dir_t_/tmp/file1').with(:command => 'semanage fcontext -a -t user_home_dir_t "/tmp/file1"') }
+    it { should contain_exec('add_user_home_dir_t_/tmp/file1').with(
+      :command => 'semanage fcontext -a -t user_home_dir_t \'/tmp/file1\'',
+      :unless => 'semanage fcontext -l | grep -P \'^\Q/tmp/file1\E.*:user_home_dir_t:\''
+    ) }
+  end
+
+  context 'set context with special characters' do
+    let(:params) { { :pathname => '/tmp/f"i$le\'1', :context => 'user_home_dir_t' } }
+    it { should contain_exec('add_user_home_dir_t_/tmp/f"i$le\'1').with(
+      :command => %q!semanage fcontext -a -t user_home_dir_t '/tmp/f"i$le'"'"'1'!,
+      :unless => %q!semanage fcontext -l | grep -P '^\Q/tmp/f"i$le'"'"'1\E.*:user_home_dir_t:'!
+    ) }
   end
 
 end


### PR DESCRIPTION
I was having some issues with `selinux::fcontext`, certain rules were re-added on every run (the `unless` property was not matching) and other rules were never added (the `unless` property was matching the wrong rule). The fcontext rules were being interpreted as a regular expression by grep.

So I added shell and regular expression escaping. Shell is simple if you use single quotes, all you have to do is replace single quotes with a double quote string that contains a single quote, for example `grep 'foo'"'"'bar'`. Regular expressions are harder, however perl regular expressions have an escape syntax using `\Qfoo\E`, all that you have to escape yourself is `\E`. That is why I am using the `-P` mode for grep.

I also changed the match itself because the `unless` property of rule `/foo` was matching `/foo/bar`