### PR TITLE
Fix for selinux::module absent case failed notify

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -58,12 +58,21 @@ define selinux::module(
     cwd          => $selinux::params::sx_mod_dir,
   }
 
+  case $ensure { # lint:ignore:case_without_default
+    present: {
+      $_checkloaded_notify = [Exec["${name}-buildmod"]]
+    }
+    absent: {
+      # buildmod doesn't exist in the absent case
+      $_checkloaded_notify = []
+    }
+  }
   exec { "${name}-checkloaded":
     refreshonly => false,
     creates     => "/etc/selinux/${selinux_policy}/modules/active/modules/${name}.pp",
 
     command     => 'true', # lint:ignore:quoted_booleans
-    notify      => Exec["${name}-buildmod"],
+    notify      => $_checkloaded_notify,
   }
 
   ## Begin Configuration

--- a/spec/defines/selinux_module_spec.rb
+++ b/spec/defines/selinux_module_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'selinux::module' do
+  let(:title) { 'mymodule' }
+  include_context 'RedHat 7'
+
+  context 'present case' do
+
+    let(:params) {{
+      :source => 'test_value'
+    }}
+
+    it { should contain_exec("mymodule-checkloaded").
+           that_notifies("Exec[mymodule-buildmod]")
+    }
+
+  end  # context
+  
+  context 'absent case' do
+
+    let(:params) {{
+      :source => 'test_value',
+      :ensure => 'absent'
+    }}
+
+    it { should_not contain_exec("mymodule-checkloaded").
+           that_notifies("Exec[mymodule-buildmod]")
+    }
+
+  end  # context
+
+end  # describe

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ facts = {
   :operatingsystem           => 'RedHat',
   :operatingsystemmajrelease => '7',
   :selinux_current_mode      => 'enforcing',
+  :selinux_config_policy     => 'targeted',
   # concat facts
   :concat_basedir => '/tmp',
   :id             => 0,


### PR DESCRIPTION
Before this, selinux::module ensure => 'absent' would fail because:
- Exec["${name}-buildmod"] wouldn't be created
- Exec["${name}-checkloaded"] therefore couldn't notify it

Also:
- Add rspec testing for selinux::module
- Add custom fact selinux_config_policy to spec_helper