### PR TITLE
add protocol to port exec to avoid duplicate resource

### DIFF
--- a/manifests/port.pp
+++ b/manifests/port.pp
@@ -38,19 +38,15 @@
 define selinux::port (
   $context,
   $port,
-  $protocol = undef,
+  $protocol,
 ) {
 
   include selinux
 
-  if $protocol {
-    validate_re($protocol, ['^tcp6?$', '^udp6?$'])
-    $protocol_switch="-p ${protocol} "
-  } else {
-    $protocol_switch=''
-  }
+  validate_re($protocol, ['^tcp6?$', '^udp6?$'])
+  $protocol_switch="-p ${protocol} "
 
-  exec { "add_${context}_${port}":
+  exec { "add_${context}_${protocol}_${port}":
     command => "semanage port -a -t ${context} ${protocol_switch}${port}",
     unless  => "semanage port -l|grep \"^${context}.*${protocol}.*${port}\"|grep -w ${port}",
     path    => '/bin:/sbin:/usr/bin:/usr/sbin',

--- a/spec/defines/selinux_port_spec.rb
+++ b/spec/defines/selinux_port_spec.rb
@@ -7,18 +7,13 @@ describe 'selinux::port' do
   ['tcp', 'udp', 'tcp6', 'udp6'].each do |protocol|
     context "valid protocol #{protocol}" do
       let(:params) { { :context => 'http_port_t', :port => 8080, :protocol => protocol } }
-      it { should contain_exec('add_http_port_t_8080').with(:command => "semanage port -a -t http_port_t -p #{protocol} 8080") }
+      it { should contain_exec("add_http_port_t_#{protocol}_8080").with(:command => "semanage port -a -t http_port_t -p #{protocol} 8080") }
     end
   end
 
   context 'invalid protocol' do
     let(:params) { { :context => 'http_port_t', :port => 8080, :protocol => 'bad' } }
     it { expect { is_expected.to compile }.to raise_error }
-  end
-
-  context 'no protocol' do
-    let(:params) { { :context => 'http_port_t', :port => 8080 } }
-    it { should contain_exec('add_http_port_t_8080').with(:command => 'semanage port -a -t http_port_t 8080') }
   end
 
 end


### PR DESCRIPTION
Hello, this is pretty much the same thing as #37 as I ran into the same problem. #37 was added in April and I'm not sure the author is coming back to fix the tests. :) Also I think protocol_port reads better than port_protocol (tcp 443, vs 443 tcp) but that's just a person preference. :)

I changed the protocol to be required instead of undef, because when I don't have it:

    # semanage port -a -t http_port_t 6666
    proto option is needed for add

I get errors, so port does not appear to be an optional parameter of 'semanage port'. So I also removed the test for no protocol.

If any errors come up in the testing I'll fix em shortly; or if you have a preference for it to be another way let me know.