### PR TITLE
Fix Issue #76

### DIFF
--- a/lib/facter/selinux_custom_policy.rb
+++ b/lib/facter/selinux_custom_policy.rb
@@ -5,7 +5,7 @@
 require 'facter'
 
 Facter.add(:selinux_custom_policy) do
-  confine kernel: 'Linux', osfamily: 'RedHat', operatingsystemmajrelease: '7', selinux: ['true', true]
+  confine :kernel => 'Linux', :osfamily => 'RedHat', :operatingsystemmajrelease => '7', :selinux => ['true', true]
   setcode do
     Facter::Util::Resolution.exec("sestatus | grep 'Loaded policy name' | awk '{ print \$4 }'")
   end


### PR DESCRIPTION
Fixing the issue as suggested by @sharkannon.

Tested on EL7
```
# cat /etc/redhat-release 
CentOS Linux release 7.2.1511 (Core)
```
```
# rpm -qa | grep -E 'puppet|facter|ruby'
rubygem-json-1.7.7-25.el7_1.x86_64
ruby-irb-2.0.0.598-25.el7_1.noarch
rubygem-bigdecimal-1.2.0-25.el7_1.x86_64
rubygem-io-console-0.4.2-25.el7_1.x86_64
ruby-shadow-2.2.0-2.el7.x86_64
ruby-augeas-0.5.0-1.el7.x86_64
libselinux-ruby-2.2.2-6.el7.x86_64
ruby-libs-2.0.0.598-25.el7_1.x86_64
rubygem-rdoc-4.0.0-25.el7_1.noarch
ruby-2.0.0.598-25.el7_1.x86_64
rubygem-psych-2.0.0-25.el7_1.x86_64
rubygems-2.0.14-25.el7_1.noarch
facter-2.4.4-1.el7.x86_64
puppet-3.8.4-1.el7.noarch`
```
and EL6 clients.
```
# cat /etc/redhat-release 
CentOS release 6.7 (Final)
```
```
[root@el6testclient01 ~]# rpm -qa | grep -E 'puppet|facter|ruby'
ruby-libs-1.8.7.374-4.el6_6.x86_64
ruby-rdoc-1.8.7.374-4.el6_6.x86_64
ruby-shadow-2.2.0-2.el6.x86_64
ruby-1.8.7.374-4.el6_6.x86_64
ruby-irb-1.8.7.374-4.el6_6.x86_64
rubygems-1.3.7-5.el6.noarch
ruby-augeas-0.4.1-3.el6.x86_64
libselinux-ruby-2.0.94-5.8.el6.x86_64
facter-2.4.4-1.el6.x86_64
rubygem-json-1.5.5-3.el6.x86_64
puppet-3.8.4-1.el6.noarch
```