### PR TITLE
Add syncversion parameter

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -33,6 +33,7 @@ define selinux::module(
   $makefile     = '/usr/share/selinux/devel/Makefile',
   $prefix       = 'local_',
   $sx_mod_dir   = '/usr/share/selinux',
+  $syncversion  = true,
 ) {
 
   require selinux
@@ -42,6 +43,7 @@ define selinux::module(
   validate_string($prefix)
   validate_absolute_path($sx_mod_dir)
   validate_absolute_path($makefile)
+  validate_bool($syncversion)
 
   $selinux_policy = $::selinux_config_policy ? {
     /targeted|strict/ => $::selinux_config_policy,
@@ -70,6 +72,6 @@ define selinux::module(
     # Warning: change the .te version!
     ensure       => $ensure,
     selmoduledir => $sx_mod_dir,
-    syncversion  => true,
+    syncversion  => $syncversion,
   }
 }


### PR DESCRIPTION
In Fedora 23, the semodule -l option doesn't return the module list anymore, and semodule --upgrade reports that it is upgraded (to use --install instead).  So this patch makes syncversion a parameter to the selinux::module type, defaulting it to true.