### PR TITLE
Remove duplicate mode parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,7 +30,6 @@ class selinux (
   $module_prefix  = $::selinux::params::module_prefix,
   $manage_package = $::selinux::params::manage_package,
   $package_name   = $::selinux::params::package_name,
-  $mode = $::selinux::params::mode,
 
   ### START Hiera Lookups ###
   $selinux_booleans = {},


### PR DESCRIPTION
Removed a duplicate parameter, in my env I get the below error:
```
error during compilation: The parameter 'mode' is declared more than once in the parameter list at puppet-fhl_main/spec/fixtures/modules/selinux/manifests/init.pp:33:3
```