### PR TITLE
Fix module installation

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -67,11 +67,11 @@ define selinux::module(
     command     => "make -f ${makefile} ${prefix}${name}.pp",
   }
   ->
-  selmodule { "${prefix}${name}":
+  selmodule { $name:
     # Load the module if it has changed or was not loaded
     # Warning: change the .te version!
-    ensure       => $ensure,
-    selmoduledir => $sx_mod_dir,
-    syncversion  => $syncversion,
+    ensure        => $ensure,
+    selmodulepath => "${sx_mod_dir}/${prefix}${name}",
+    syncversion   => $syncversion,
   }
 }

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -71,7 +71,7 @@ define selinux::module(
     # Load the module if it has changed or was not loaded
     # Warning: change the .te version!
     ensure        => $ensure,
-    selmodulepath => "${sx_mod_dir}/${prefix}${name}",
+    selmodulepath => "${sx_mod_dir}/${prefix}${name}.pp",
     syncversion   => $syncversion,
   }
 }

--- a/spec/defines/selinux_module_spec.rb
+++ b/spec/defines/selinux_module_spec.rb
@@ -14,7 +14,7 @@ describe 'selinux::module' do
     it do
       should contain_file('/usr/share/selinux/local_mymodule.te').that_notifies('Exec[/usr/share/selinux/local_mymodule.pp]')
 
-      should contain_selmodule('local_mymodule').with_ensure('present')
+      should contain_selmodule('mymodule').with_ensure('present')
     end
   end  # context
 
@@ -27,7 +27,7 @@ describe 'selinux::module' do
     end
 
     it do
-      should contain_selmodule('local_mymodule')
+      should contain_selmodule('mymodule')
         .with_ensure('absent')
     end
   end  # context


### PR DESCRIPTION
The fix changes the module name that is provided for selmodule from
${prefix}${name} to $name. The module shouldn't reload selinux module
anymore on every run as now selinux module name matches with the name
provided.

Should fix #90 