### PR TITLE
Added support for running restorecon after modifying file contexts

### DIFF
--- a/spec/defines/selinux_fcontext_spec.rb
+++ b/spec/defines/selinux_fcontext_spec.rb
@@ -23,15 +23,28 @@ describe 'selinux::fcontext' do
   context 'substituting fcontext' do
     let(:params) { { pathname: '/tmp/file1', equals: true, destination: '/tmp/file2' } }
     it { should contain_exec('add_/tmp/file2_/tmp/file1').with(command: 'semanage fcontext -a -e "/tmp/file2" "/tmp/file1"') }
+    it { should contain_exec('restorecond add_/tmp/file2_/tmp/file1').with(command: 'restorecon /tmp/file1') }
   end
 
   context 'set filemode and context' do
     let(:params) { { pathname: '/tmp/file1', filetype: true, filemode: 'a', context: 'user_home_dir_t' } }
     it { should contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(command: 'semanage fcontext -a -f a -t user_home_dir_t "/tmp/file1"') }
+    it { should contain_exec('restorecond add_user_home_dir_t_/tmp/file1_type_a').with(command: 'restorecon /tmp/file1') }
   end
 
   context 'set context' do
     let(:params) { { pathname: '/tmp/file1', context: 'user_home_dir_t' } }
     it { should contain_exec('add_user_home_dir_t_/tmp/file1').with(command: 'semanage fcontext -a -t user_home_dir_t "/tmp/file1"') }
+    it { should contain_exec('restorecond add_user_home_dir_t_/tmp/file1').with(command: 'restorecon /tmp/file1') }
+  end
+
+  context 'with restorecon disabled' do
+    let(:params) { { pathname: '/tmp/file1', context: 'user_home_dir_t', restorecond: false } }
+    it { should_not contain_exec('restorecond add_user_home_dir_t_/tmp/file1').with(command: 'restorecon /tmp/file1') }
+  end
+  context 'with restorecon specific path' do
+    let(:params) { { pathname: '/tmp/file1', context: 'user_home_dir_t', restorecond_path: '/tmp/file1/different' } }
+    it { should contain_exec('add_user_home_dir_t_/tmp/file1').with(command: 'semanage fcontext -a -t user_home_dir_t "/tmp/file1"') }
+    it { should contain_exec('restorecond add_user_home_dir_t_/tmp/file1').with(command: 'restorecon /tmp/file1/different') }
   end
 end


### PR DESCRIPTION

The fcontext defined type sets the permanent state, but you still have to run restorecon to actually make that change take effect.   This is a proposal that by default will always run restorecon on the pathname (unless disabled with the $restorecond = false flag set)

Happy to look at better ways of doing this, but I wanted to be able to make the changes take effect without having to take a second step in puppet.
